### PR TITLE
Add basic Hextra docs site

### DIFF
--- a/spectest-docs/content/_index.md
+++ b/spectest-docs/content/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Spectest Documentation"
+---
+
+Welcome to the Spectest documentation.

--- a/spectest-docs/content/docs/_index.md
+++ b/spectest-docs/content/docs/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Documentation"
+---

--- a/spectest-docs/content/docs/api/_index.md
+++ b/spectest-docs/content/docs/api/_index.md
@@ -1,0 +1,4 @@
+---
+title: "API References"
+weight: 3
+---

--- a/spectest-docs/content/docs/api/cli.md
+++ b/spectest-docs/content/docs/api/cli.md
@@ -1,0 +1,4 @@
+---
+title: "CLI"
+weight: 1
+---

--- a/spectest-docs/content/docs/api/suite.md
+++ b/spectest-docs/content/docs/api/suite.md
@@ -1,0 +1,4 @@
+---
+title: "Suite"
+weight: 2
+---

--- a/spectest-docs/content/docs/api/test-case.md
+++ b/spectest-docs/content/docs/api/test-case.md
@@ -1,0 +1,4 @@
+---
+title: "Test Case"
+weight: 3
+---

--- a/spectest-docs/content/docs/guides/_index.md
+++ b/spectest-docs/content/docs/guides/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Guides"
+weight: 2
+---

--- a/spectest-docs/content/docs/guides/environment-variables.md
+++ b/spectest-docs/content/docs/guides/environment-variables.md
@@ -1,0 +1,4 @@
+---
+title: "Environment Variables"
+weight: 3
+---

--- a/spectest-docs/content/docs/guides/reporting.md
+++ b/spectest-docs/content/docs/guides/reporting.md
@@ -1,0 +1,4 @@
+---
+title: "Reporting"
+weight: 4
+---

--- a/spectest-docs/content/docs/guides/snapshots.md
+++ b/spectest-docs/content/docs/guides/snapshots.md
@@ -1,0 +1,4 @@
+---
+title: "Snapshots"
+weight: 2
+---

--- a/spectest-docs/content/docs/guides/test-filtering.md
+++ b/spectest-docs/content/docs/guides/test-filtering.md
@@ -1,0 +1,4 @@
+---
+title: "Test Filtering"
+weight: 1
+---

--- a/spectest-docs/content/docs/integrations/_index.md
+++ b/spectest-docs/content/docs/integrations/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Integrations"
+weight: 4
+---

--- a/spectest-docs/content/docs/integrations/jest.md
+++ b/spectest-docs/content/docs/integrations/jest.md
@@ -1,0 +1,4 @@
+---
+title: "Jest"
+weight: 1
+---

--- a/spectest-docs/content/docs/integrations/vitest.md
+++ b/spectest-docs/content/docs/integrations/vitest.md
@@ -1,0 +1,4 @@
+---
+title: "Vitest"
+weight: 2
+---

--- a/spectest-docs/content/docs/introduction/_index.md
+++ b/spectest-docs/content/docs/introduction/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Introduction"
+weight: 1
+---

--- a/spectest-docs/content/docs/introduction/concepts.md
+++ b/spectest-docs/content/docs/introduction/concepts.md
@@ -1,0 +1,4 @@
+---
+title: "Concepts"
+weight: 2
+---

--- a/spectest-docs/content/docs/introduction/getting-started.md
+++ b/spectest-docs/content/docs/introduction/getting-started.md
@@ -1,0 +1,4 @@
+---
+title: "Getting Started"
+weight: 1
+---

--- a/spectest-docs/content/docs/introduction/helpers.md
+++ b/spectest-docs/content/docs/introduction/helpers.md
@@ -1,0 +1,4 @@
+---
+title: "Helpers"
+weight: 5
+---

--- a/spectest-docs/content/docs/introduction/organizing-test-suites.md
+++ b/spectest-docs/content/docs/introduction/organizing-test-suites.md
@@ -1,0 +1,4 @@
+---
+title: "Organizing Test Suites"
+weight: 4
+---

--- a/spectest-docs/content/docs/introduction/testing-http-apis.md
+++ b/spectest-docs/content/docs/introduction/testing-http-apis.md
@@ -1,0 +1,4 @@
+---
+title: "Testing HTTP APIs"
+weight: 3
+---

--- a/spectest-docs/content/docs/more/_index.md
+++ b/spectest-docs/content/docs/more/_index.md
@@ -1,0 +1,4 @@
+---
+title: "More"
+weight: 5
+---

--- a/spectest-docs/content/docs/more/about.md
+++ b/spectest-docs/content/docs/more/about.md
@@ -1,0 +1,4 @@
+---
+title: "About"
+weight: 1
+---

--- a/spectest-docs/content/docs/more/terms-of-service.md
+++ b/spectest-docs/content/docs/more/terms-of-service.md
@@ -1,0 +1,4 @@
+---
+title: "Terms of Service"
+weight: 2
+---

--- a/spectest-docs/hugo.toml
+++ b/spectest-docs/hugo.toml
@@ -1,3 +1,27 @@
-baseURL = 'https://example.org/'
+[module]
+  [[module.imports]]
+    path = "github.com/imfing/hextra"
+
+baseURL = '/'
 languageCode = 'en-us'
-title = 'My New Hugo Site'
+title = 'Spectest Documentation'
+theme = 'github.com/imfing/hextra'
+
+[params]
+  logo = 'https://raw.githubusercontent.com/justiceo/spectest/refs/heads/main/assets/spectest-logo-transparent.png'
+  description = 'Documentation for Spectest'
+  search = true
+  darkMode = true
+
+[menu]
+  [[menu.main]]
+    identifier = 'home'
+    name = 'Home'
+    pageRef = '/'
+    weight = 1
+
+  [[menu.main]]
+    identifier = 'docs'
+    name = 'Documentation'
+    pageRef = '/docs'
+    weight = 2


### PR DESCRIPTION
## Summary
- create Hugo doc structure under spectest-docs
- configure Hextra theme and nav links
- add empty pages for docs sections

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bbe1fd0e4832e9fc8a0e3f3b0c222