### PR TITLE
Add new Spectest docs homepage

### DIFF
--- a/spectest-docs/content/_index.md
+++ b/spectest-docs/content/_index.md
@@ -1,5 +1,40 @@
 ---
 title: "Spectest"
+description: "Lightning fast and declarative API testing"
 ---
 
-Spectest makes HTTP API testing fast and declarative. This documentation walks you through installation, key concepts and practical tips so you can validate APIs with ease.
+{{< hero title="API testing without the pain" tagline="Spectest lets you describe HTTP endpoints and verify them in seconds" image="https://raw.githubusercontent.com/justiceo/spectest/refs/heads/main/assets/spectest-logo-transparent.png" cta_text="Get Started" cta_url="/docs/introduction/getting-started/" >}}
+
+## Key Features
+
+{{< cards >}}
+{{< card icon="bolt" title="Truly Declarative" >}}
+Write tests as plain objects that mirror Fetch Request and Response schemas.
+{{< /card >}}
+{{< card icon="zap" title="Ridiculously Fast" >}}
+Runs requests in parallel with smart rate limiting so suites finish in no time.
+{{< /card >}}
+{{< card icon="crosshair" title="Focused Workflow" >}}
+Filter, tag, randomize and bombard endpoints for robust coverage.
+{{< /card >}}
+{{< /cards >}}
+
+## Quick Start
+
+{{< button href="/docs/introduction/getting-started/" >}}Read the getting started guide{{< /button >}}
+
+```js
+// simple.spectest.js
+export default [
+  { name: 'Fetch TODO 1', endpoint: '/todos/1' }
+]
+```
+
+## Explore the docs
+
+{{< cards >}}
+{{< card icon="rocket" title="Getting Started" href="/docs/introduction/getting-started/" / >}}
+{{< card icon="book" title="Guides" href="/docs/guides/" / >}}
+{{< card icon="file-text" title="API Reference" href="/docs/api/" / >}}
+{{< card icon="plug" title="Integrations" href="/docs/integrations/" / >}}
+{{< /cards >}}


### PR DESCRIPTION
## Summary
- create a rich landing page for Spectest docs

## Testing
- `npm test` *(fails: 403 Forbidden fetching esbuild)*

------
https://chatgpt.com/codex/tasks/task_b_687bcf169e10832eae009300ac7e19f0