### PR TITLE
Add advanced Spectest guide docs

### DIFF
--- a/spectest-docs/content/docs/guides/_index.md
+++ b/spectest-docs/content/docs/guides/_index.md
@@ -2,3 +2,10 @@
 title: "Guides"
 weight: 2
 ---
+
+Practical walk‑throughs for key Spectest features. These pages dive deeper into filtering large suites, working with snapshots and controlling the environment. Use them alongside the introduction material to build a robust workflow.
+
+- [Test Filtering](./test-filtering/)
+- [Snapshots](./snapshots/)
+- [Environment Variables](./environment-variables/)
+- [Reporting](./reporting/)

--- a/spectest-docs/content/docs/guides/environment-variables.md
+++ b/spectest-docs/content/docs/guides/environment-variables.md
@@ -2,3 +2,43 @@
 title: "Environment Variables"
 weight: 3
 ---
+
+Because the configuration file is plain JavaScript you can easily incorporate environment variables. This lets you keep secrets and server addresses outside of source control.
+
+## Using Env Vars in Configuration
+
+```js
+// spectest.config.js
+export default {
+  baseUrl: process.env.API_BASE_URL,
+  testDir: './test',
+  filePattern: '\\.spectest\\.',
+};
+```
+
+Set `API_BASE_URL` before invoking Spectest and the tests will target that server:
+
+```bash
+API_BASE_URL=https://staging.example.com npx spectest
+```
+
+## Passing Secrets
+
+Sensitive values such as authentication tokens can be injected in a `beforeSend` hook or read from the environment inside your suite.
+
+```js
+export default [
+  {
+    name: 'Fetch profile',
+    endpoint: '/profile',
+    beforeSend: req => {
+      req.headers = { ...req.headers, Authorization: `Bearer ${process.env.API_TOKEN}` };
+    },
+    response: { status: 200 }
+  }
+];
+```
+
+## CI/CD Integration
+
+In a pipeline, export the required environment variables as part of the job configuration. Spectest exits with a non-zero status on failures so it fits naturally into `npm test` or dedicated testing steps.

--- a/spectest-docs/content/docs/guides/reporting.md
+++ b/spectest-docs/content/docs/guides/reporting.md
@@ -2,3 +2,42 @@
 title: "Reporting"
 weight: 4
 ---
+
+The CLI prints a concise summary after every run. With the `--verbose` flag you also get server logs grouped under each case.
+
+## Standard Output
+
+Each suite is listed with the individual results:
+
+```text
+📊 Test Summary:
+ [✅] Login (45ms)
+ [❌] Fetch profile (140ms)
+```
+
+Latency statistics and the overall pass count appear at the end. A non‑zero exit code indicates failures which CI systems can detect.
+
+## Verbose Mode
+
+Enable verbose output when debugging to see request identifiers and server log lines:
+
+```bash
+npx spectest --verbose
+```
+
+Any `console` output from your server is collected and printed beneath the related test when verbose mode is on or when the test fails.
+
+## Snapshot Reports
+
+When using `--snapshot` the report file contains the same pass/fail status and latency numbers. This makes it possible to compare historical runs or feed the data into external dashboards.
+
+## Continuous Integration
+
+Add Spectest to your pipeline by executing the CLI as part of your test job. Example using GitHub Actions:
+
+```yaml
+- name: Run API tests
+  run: npx spectest --base-url=$URL --snapshot=reports/snapshot.json
+```
+
+Upload the snapshot or parse the console output to visualize results over time.

--- a/spectest-docs/content/docs/guides/snapshots.md
+++ b/spectest-docs/content/docs/guides/snapshots.md
@@ -2,3 +2,40 @@
 title: "Snapshots"
 weight: 2
 ---
+
+Snapshots capture the exact requests and responses from a test run. They are invaluable when reviewing failures or updating expected data.
+
+## Creating a Snapshot
+
+Pass the `--snapshot` flag with a file path. After the run, Spectest writes a JSON report containing each case with its final request, response and overall status.
+
+```bash
+npx spectest --snapshot=.spectest/snap.json
+```
+
+The file structure resembles:
+
+```json
+{
+  "lastUpdate": "2024-05-01 15:04 PDT",
+  "cases": [
+    {
+      "name": "Create user",
+      "operationId": "Create user",
+      "suite": "auth",
+      "request": { "method": "POST", "url": "/users" },
+      "response": { "status": 201, "data": { "id": 5 } },
+      "status": "pass",
+      "latency": 120
+    }
+  ]
+}
+```
+
+## Updating Tests
+
+Copy the captured response bodies back into your suite to keep expectations in sync. You can also rerun only failing cases with `--filter=failures` which consults the snapshot file.
+
+## CI Usage
+
+Snapshots make it easy to archive historical runs in your CI pipeline. Commit the JSON artifacts or upload them to your results store for later comparison.

--- a/spectest-docs/content/docs/guides/test-filtering.md
+++ b/spectest-docs/content/docs/guides/test-filtering.md
@@ -2,3 +2,49 @@
 title: "Test Filtering"
 weight: 1
 ---
+
+Large projects quickly accumulate dozens of suites. Spectest provides several mechanisms to target a subset of tests when you only need to run a portion of them.
+
+## By File
+
+Use `--suite-file` to run a single suite or `--file-pattern` to limit the discovery step.
+
+```bash
+npx spectest auth.spectest.js
+npx spectest --file-pattern="auth*"
+```
+
+## Tags
+
+Tag your cases then pass a comma separated list via `--tags`.
+
+```js
+export default [
+  { name: 'Create user', endpoint: '/users', tags: ['users','create'] },
+  { name: 'List users', endpoint: '/users', tags: ['users','list'] },
+];
+```
+
+```bash
+npx spectest --tags=users
+npx spectest --tags=users,list
+```
+
+## Name Patterns and Smart Filters
+
+`--filter` accepts a regular expression or one of the built in aliases:
+
+- `happy` – only cases expecting a 2xx status
+- `failures` – rerun tests that failed in the last snapshot
+
+```bash
+npx spectest --filter="Login"
+```
+
+## Focus and Skip
+
+When investigating a failing case you can mark it with `focus: true` to ignore the rest. Similarly `skip: true` temporarily disables a case. The `focus()` and `skip()` helpers apply these flags to entire suites.
+
+## Randomization and Dependencies
+
+`--randomize` shuffles the remaining tests after filtering. Use `dependsOn` inside a case to declare prerequisites so dependent operations run after their parents succeed.


### PR DESCRIPTION
## Summary
- flesh out guides section with an overview
- document running specific suites and filters
- explain snapshot testing and usage
- add environment variable tips
- describe CLI reporting and verbose mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687c0c210494832eb6b2c431a18c2609