### PR TITLE
Add Spectest API reference docs

### DIFF
--- a/spectest-docs/content/docs/api-references/_index.md
+++ b/spectest-docs/content/docs/api-references/_index.md
@@ -1,0 +1,12 @@
+---
+title: "API References"
+weight: 3
+---
+
+Comprehensive reference for Spectest APIs including the command line interface and the test suite format.
+
+Use the links below to explore each area:
+
+- [CLI](./cli/)
+- [Test Suite](./suite/)
+- [Test Case](./test-case/)

--- a/spectest-docs/content/docs/api-references/cli.md
+++ b/spectest-docs/content/docs/api-references/cli.md
@@ -1,0 +1,48 @@
+---
+title: "CLI"
+weight: 1
+---
+
+The `spectest` command runs suites and manages the test environment. All options correspond to configuration fields and may be supplied via the config file or the command line.
+
+```bash
+npx spectest [suiteFile] [options]
+```
+
+### Options
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `--config=<file>` | Load additional configuration from file | none |
+| `--base-url=<url>` | Base URL for all requests | `https://localhost:8080` |
+| `--test-dir=<dir>` | Directory containing test suites | `./test` |
+| `--file-pattern=<regex>` | Pattern used to locate suite files | `\.spectest\.` |
+| `--start-cmd=<cmd>` | Command used to start the server | `npm run start` |
+| `--running-server=<reuse|fail|kill>` | How to handle an already running server | `reuse` |
+| `--tags=<list>` | Comma separated tags for filtering | none |
+| `--rps=<number>` | Requests per second limit | `Infinity` |
+| `--timeout=<ms>` | Default per‑test timeout | `30000` |
+| `--snapshot=<file>` | Write snapshot JSON to file | none |
+| `--randomize` | Shuffle execution order | `false` |
+| `--happy` | Run only tests expecting a 2xx status | `false` |
+| `--filter=<pattern>` | Regex or built‑in filter (`happy`, `failures`) | none |
+| `--verbose` | Print detailed logs | `false` |
+| `--user-agent=<name>` | Override the User‑Agent header | `chrome_windows` |
+| `--ua=<name>` | Alias of `--user-agent` | |
+
+Provide a file path without a flag to run just that suite.
+
+See [Test Suite](./suite/) and [Test Case](./test-case/) for details on the file format.
+
+### Examples
+
+```bash
+# Run every suite discovered in testDir
+npx spectest
+
+# Only run a specific file
+npx spectest auth.spectest.js
+
+# Run with mobile user agent and record snapshots
+npx spectest --user-agent=chrome_android --snapshot=snap.json
+```

--- a/spectest-docs/content/docs/api-references/suite.md
+++ b/spectest-docs/content/docs/api-references/suite.md
@@ -1,0 +1,29 @@
+---
+title: "Test Suite"
+weight: 2
+---
+
+A **suite** is a file that exports either an array of test cases or an object with a `name` and `tests` array. Spectest loads every file under `testDir` matching `filePattern` and runs the contained cases.
+
+```js
+// basic array
+export default [
+  { name: 'Fetch TODO 1', endpoint: '/todos/1' },
+  { name: 'Create Post', endpoint: '/posts', request: { method: 'POST' } }
+];
+```
+
+```js
+// named suite
+export default {
+  name: 'Comments Tests',
+  tests: [
+    { name: 'List', endpoint: '/comments/' },
+    { name: 'Get 1', endpoint: '/comments/1' }
+  ]
+};
+```
+
+Suites may use CommonJS, ES modules or JSON. Each file becomes its own suite and the file name (without extension) is used when no name is provided.
+
+Related: [Test Case](./test-case/) for the available case options.

--- a/spectest-docs/content/docs/api-references/test-case.md
+++ b/spectest-docs/content/docs/api-references/test-case.md
@@ -1,0 +1,55 @@
+---
+title: "Test Case"
+weight: 3
+---
+
+A **test case** describes a single HTTP operation. Only `name` and `endpoint` are required. All other fields are optional and mirror the [`fetch` Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects.
+
+### Properties
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `name` | Human readable test name | required |
+| `operationId` | Unique identifier for the operation | `name` |
+| `dependsOn` | Array of operationId strings that must pass first | none |
+| `endpoint` | Request path relative to the base URL | required |
+| `request.method` | HTTP method | `GET` |
+| `request.headers` | Additional request headers | none |
+| `request.body` | Request payload | none |
+| `request.*` | Any other valid fetch Request option | none |
+| `response.status` | Expected HTTP status | `200` |
+| `response.json` | Expected partial JSON body | none |
+| `response.schema` | Zod or JSON schema to validate response | none |
+| `response.headers` | Expected response headers | none |
+| `response.*` | Other fetch Response fields | none |
+| `beforeSend(req, state)` | Function to finalize the request | none |
+| `postTest(res, state, ctx)` | Function called after the response | none |
+| `tags` | Tags used with `--tags` filtering | none |
+| `skip` | Skip this test | `false` |
+| `focus` | Run only focused tests when present | `false` |
+| `repeat` | Extra sequential runs of the test | `0` |
+| `bombard` | Additional simultaneous runs of the test | `0` |
+| `delay` | Milliseconds to wait before running | none |
+| `timeout` | Per‑test timeout override | runtime `timeout` |
+
+### Example
+
+```js
+{
+  name: 'Create a post',
+  endpoint: '/posts',
+  request: {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: { title: 'foo', body: 'bar', userId: 1 }
+  },
+  response: {
+    status: 201,
+    json: { id: 101, title: 'foo', body: 'bar', userId: 1 }
+  }
+}
+```
+
+If the server returns `201` with a matching body the case passes. Any mismatched status or body value results in a failure.
+
+See [Helpers](../introduction/helpers/) for utilities that modify multiple cases at once.


### PR DESCRIPTION
## Summary
- document CLI command usage and options
- document the test suite format
- document individual test case options

## Testing
- `npm test` *(fails: 7/8 tests passed with network blocks)*

------
https://chatgpt.com/codex/tasks/task_b_687c0f2fb6b0832e98f2f29361d7ae7d